### PR TITLE
Use views instead of sequences

### DIFF
--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -15,7 +15,7 @@ Dataclass tools for data namespaces (bins)
 """
 from __future__ import annotations
 
-from typing import Any, Iterable, Sequence
+from typing import Any, ItemsView, Iterable, KeysView, ValuesView
 
 import numpy as np
 
@@ -43,6 +43,8 @@ class DataBin(ShapedMixin):
         print("beta data:", data.beta)
 
     """
+
+    __slots__ = ("_data", "_shape")
 
     _RESTRICTED_NAMES = frozenset(
         {
@@ -112,17 +114,17 @@ class DataBin(ShapedMixin):
     def __iter__(self) -> Iterable[str]:
         return iter(self._data)
 
-    def keys(self) -> Sequence[str]:
-        """Return a list of field names."""
-        return list(self._data)
+    def keys(self) -> KeysView[str]:
+        """Return a view of field names."""
+        return self._data.keys()
 
-    def values(self) -> Sequence[Any]:
-        """Return a list of values."""
-        return list(self._data.values())
+    def values(self) -> ValuesView[Any]:
+        """Return a view of values."""
+        return self._data.values()
 
-    def items(self) -> Sequence[tuple[str, Any]]:
-        """Return a list of field names and values"""
-        return list(self._data.items())
+    def items(self) -> ItemsView[str, Any]:
+        """Return a view of field names and values"""
+        return self._data.items()
 
     # The following properties exist to provide support to legacy private class attributes which
     # gained widespread prior to qiskit 1.1. These properties will be removed once the internal

--- a/test/python/primitives/containers/test_data_bin.py
+++ b/test/python/primitives/containers/test_data_bin.py
@@ -82,14 +82,14 @@ class DataBinTestCase(QiskitTestCase):
                 _ = next(iterator)
 
         with self.subTest("keys"):
-            lst = data_bin.keys()
+            lst = list(data_bin.keys())
             key = lst[0]
             self.assertEqual(key, "alpha")
             key = lst[1]
             self.assertEqual(key, "beta")
 
         with self.subTest("values"):
-            lst = data_bin.values()
+            lst = list(data_bin.values())
             val = lst[0]
             self.assertIsInstance(val, int)
             self.assertEqual(val, 10)
@@ -98,7 +98,7 @@ class DataBinTestCase(QiskitTestCase):
             self.assertEqual(val, {1: 2})
 
         with self.subTest("items"):
-            lst = data_bin.items()
+            lst = list(data_bin.items())
             key, val = lst[0]
             self.assertEqual(key, "alpha")
             self.assertIsInstance(val, int)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

The internal data structure becomes only a dict and shape. So, we can simplify the code as follows.
- We can specify `__slots__` because DataBin has only these items now.
- Views of keys, values, items might be good because we can reduce the overhead to make a list.

### Details and comments


